### PR TITLE
add reason as syntax highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the "omt-odt-language" extension will be documented in th
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [2.2.2]
+
+### Added
+
+- OMT highlighting support for:
+  - the `reason` property for `Activities`s
+
 ## [2.2.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 
 - OMT highlighting support for:
-  - the `reason` property for `Activities`s
+  - the `reason` property for an `Activity`
 
 ## [2.2.1]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "omt-odt-language",
-    "version": "2.2.0",
+    "version": "2.2.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "omt-odt-language",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "license": "Apache-2.0",
     "displayName": "OMT & ODT",
     "description": "A language extension for the OMT and ODT languages",

--- a/syntaxes/omt.tmLanguage.json
+++ b/syntaxes/omt.tmLanguage.json
@@ -91,6 +91,17 @@
                     "patterns": [{ "include": "#_interpolated-odt" }]
                 },
                 {
+                    "match": "(?:\\G|^) +(reason): *([\\w ]*)(.*)$",
+                    "captures": {
+                        "1": { "name": "keyword.control.omt" },
+                        "2": {
+                            "name": "string.unquoted.omt",
+                            "patterns": [{ "include": "#_escape" }]
+                        },
+                        "3": { "patterns": [{ "include": "#_comments-only" }] }
+                    }
+                },
+                {
                     "begin": "^ +(returns): +",
                     "beginCaptures": {
                         "1": { "name": "keyword.control.omt" }


### PR DESCRIPTION
Add syntax highlight support for the property reason in omt. This property is optional and therefor not added in the code snippet 